### PR TITLE
Implement pipeline management services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "mcp[cli]>=1.6.0",
     "pydantic>=2.11.3",
     "pydantic-settings>=2.8.1",
-    "asyncio>=3.4.3",
 ]
 authors = [{ name = "Adit pal Singh", email = "aditpalsing@gmail.com" }]
 license = { file = "LICENSE" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ anyio==4.9.0
     #   mcp
     #   sse-starlette
     #   starlette
-asyncio==3.4.3
-    # via gitlab-mcp (pyproject.toml)
 certifi==2025.1.31
     # via
     #   httpcore

--- a/server.py
+++ b/server.py
@@ -44,6 +44,11 @@ from src.services.merge_requests import (
     merge_request_changes,
     update_merge_request,
 )
+from src.services.pipelines import (
+    get_latest_pipeline,
+    get_single_pipeline,
+    list_project_pipelines,
+)
 from src.services.repositories import create_repository, list_repository_tree
 from src.services.search import search_globally, search_group, search_project
 
@@ -172,6 +177,20 @@ mcp.tool(
 mcp.tool(
     name="create_merge_request_comment", description="Add a comment to a merge request."
 )(create_merge_request_comment)
+
+# Register pipeline tools
+mcp.tool(
+    name="list_project_pipelines",
+    description="List pipelines in a GitLab project.",
+)(list_project_pipelines)
+mcp.tool(
+    name="get_single_pipeline",
+    description="Get a single pipeline by ID for a GitLab project.",
+)(get_single_pipeline)
+mcp.tool(
+    name="get_latest_pipeline",
+    description="Get the latest pipeline for the most recent commit on a specific ref.",
+)(get_latest_pipeline)
 
 # Register job tools
 

--- a/src/schemas/pipelines.py
+++ b/src/schemas/pipelines.py
@@ -1,0 +1,43 @@
+"""Pydantic models for GitLab pipeline operations."""
+
+from pydantic import BaseModel, HttpUrl
+
+from src.schemas.base import BaseResponseList, GitLabResponseBase
+
+
+class GitLabPipeline(GitLabResponseBase):
+    """Response model for a GitLab pipeline."""
+
+    id: int
+    sha: str | None = None
+    ref: str | None = None
+    status: str | None = None
+    web_url: HttpUrl | None = None
+
+
+class ListProjectPipelinesInput(BaseModel):
+    """Input model for listing pipelines in a GitLab project."""
+
+    project_path: str
+    page: int = 1
+    per_page: int = 20
+
+
+class GitLabPipelineList(BaseResponseList[GitLabPipeline]):
+    """Response model for listing project pipelines."""
+
+    pass
+
+
+class GetSinglePipelineInput(BaseModel):
+    """Input model for retrieving a single pipeline."""
+
+    project_path: str
+    pipeline_id: int
+
+
+class GetLatestPipelineInput(BaseModel):
+    """Input model for retrieving the latest pipeline for a ref."""
+
+    project_path: str
+    ref: str

--- a/src/services/pipelines.py
+++ b/src/services/pipelines.py
@@ -1,0 +1,108 @@
+"""Service functions for interacting with GitLab pipelines."""
+
+from src.api.custom_exceptions import GitLabAPIError, GitLabErrorType
+from src.api.rest_client import gitlab_rest_client
+from src.schemas.pipelines import (
+    GetLatestPipelineInput,
+    GetSinglePipelineInput,
+    GitLabPipeline,
+    GitLabPipelineList,
+    ListProjectPipelinesInput,
+)
+
+
+async def list_project_pipelines(
+    input_model: ListProjectPipelinesInput,
+) -> GitLabPipelineList:
+    """List pipelines for a project."""
+    try:
+        project_path = gitlab_rest_client._encode_path_parameter(
+            input_model.project_path
+        )
+        params = {
+            "page": input_model.page,
+            "per_page": input_model.per_page,
+        }
+        response = await gitlab_rest_client.get_async(
+            f"/projects/{project_path}/pipelines",
+            params=params,
+        )
+        items = [GitLabPipeline.model_validate(p) for p in response]
+        return GitLabPipelineList(items=items)
+    except GitLabAPIError as exc:
+        raise GitLabAPIError(
+            GitLabErrorType.REQUEST_FAILED,
+            {
+                "message": f"Failed to list pipelines for {input_model.project_path}",
+                "operation": "list_project_pipelines",
+            },
+        ) from exc
+    except Exception as exc:
+        raise GitLabAPIError(
+            GitLabErrorType.SERVER_ERROR,
+            {
+                "message": "Internal error listing pipelines",
+                "operation": "list_project_pipelines",
+            },
+        ) from exc
+
+
+async def get_single_pipeline(
+    input_model: GetSinglePipelineInput,
+) -> GitLabPipeline:
+    """Get a single pipeline by ID."""
+    try:
+        project_path = gitlab_rest_client._encode_path_parameter(
+            input_model.project_path
+        )
+        response = await gitlab_rest_client.get_async(
+            f"/projects/{project_path}/pipelines/{input_model.pipeline_id}"
+        )
+        return GitLabPipeline.model_validate(response)
+    except GitLabAPIError as exc:
+        if "not found" in str(exc).lower():
+            raise GitLabAPIError(
+                GitLabErrorType.NOT_FOUND,
+                {"message": f"Pipeline {input_model.pipeline_id} not found"},
+            ) from exc
+        raise GitLabAPIError(
+            GitLabErrorType.REQUEST_FAILED,
+            {
+                "message": f"Failed to get pipeline {input_model.pipeline_id}",
+                "operation": "get_single_pipeline",
+            },
+        ) from exc
+    except Exception as exc:
+        raise GitLabAPIError(
+            GitLabErrorType.SERVER_ERROR,
+            {"message": "Internal error getting pipeline", "operation": "get_single_pipeline"},
+        ) from exc
+
+
+async def get_latest_pipeline(
+    input_model: GetLatestPipelineInput,
+) -> GitLabPipeline:
+    """Get the latest pipeline for a ref."""
+    try:
+        project_path = gitlab_rest_client._encode_path_parameter(
+            input_model.project_path
+        )
+        params = {"ref": input_model.ref, "per_page": 1}
+        response = await gitlab_rest_client.get_async(
+            f"/projects/{project_path}/pipelines",
+            params=params,
+        )
+        if not response:
+            raise GitLabAPIError(
+                GitLabErrorType.NOT_FOUND,
+                {"message": "No pipelines found"},
+            )
+        latest = response[0]
+        return GitLabPipeline.model_validate(latest)
+    except GitLabAPIError:
+        raise
+    except Exception as exc:
+        raise GitLabAPIError(
+            GitLabErrorType.SERVER_ERROR,
+            {"message": "Internal error getting latest pipeline", "operation": "get_latest_pipeline"},
+        ) from exc

--- a/uv.lock
+++ b/uv.lock
@@ -25,15 +25,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncio"
-version = "3.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/54/054bafaf2c0fb8473d423743e191fcdf49b2c1fd5e9af3524efbe097bafd/asyncio-3.4.3.tar.gz", hash = "sha256:83360ff8bc97980e4ff25c964c7bd3923d333d177aa4f7fb736b019f26c7cb41", size = 204411 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/74/07679c5b9f98a7cb0fc147b1ef1cc1853bc07a4eb9cb5731e24732c5f773/asyncio-3.4.3-py3-none-any.whl", hash = "sha256:c4d18b22701821de07bd6aea8b53d21449ec0ec5680645e5317062ea21817d2d", size = 101767 },
-]
-
-[[package]]
 name = "black"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -113,7 +104,6 @@ name = "gitlab-mcp-server"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "asyncio" },
     { name = "dotenv" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
@@ -134,7 +124,6 @@ ruff = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncio", specifier = ">=3.4.3" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.2.0" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Summary
- add pydantic models for GitLab pipelines
- implement service functions for listing and retrieving project pipelines
- register new pipeline tools in the MCP server

## Testing
- `ruff check .`
